### PR TITLE
Upping Compatibility to Python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Dave Harding
+Copyright (c) 2024 Dave Harding
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/snake_example.py
+++ b/examples/snake_example.py
@@ -21,20 +21,21 @@ class Direction(Enum):
     LEFT = 4
 
 
-def determine_snake_direction(event_key: int, snake_direction: Direction) -> Direction:
-    if event_key == pygame.K_UP and \
-            snake_direction != Direction.DOWN:
-        return Direction.UP
-    elif event_key == pygame.K_RIGHT and \
-            snake_direction != Direction.LEFT:
-        return Direction.RIGHT
-    elif event_key == pygame.K_DOWN and \
-            snake_direction != Direction.UP:
-        return Direction.DOWN
-    elif event_key == pygame.K_LEFT and \
-            snake_direction != Direction.RIGHT:
-        return Direction.LEFT
-    
+def determine_snake_direction(event: pygame.event, snake_direction: Direction) -> Direction:
+    if event.type == pygame.KEYDOWN:
+        if event.key == pygame.K_UP and \
+                snake_direction != Direction.DOWN:
+            return Direction.UP
+        elif event.key == pygame.K_RIGHT and \
+                snake_direction != Direction.LEFT:
+            return Direction.RIGHT
+        elif event.key == pygame.K_DOWN and \
+                snake_direction != Direction.UP:
+            return Direction.DOWN
+        elif event.key == pygame.K_LEFT and \
+                snake_direction != Direction.RIGHT:
+            return Direction.LEFT
+
     return snake_direction
 
 
@@ -57,6 +58,20 @@ def determine_snake_position(snake_direction: Direction, snake_head_top: int, sn
             snake_head_left = 9
 
     return snake_head_top, snake_head_left
+
+
+def keep_game_running(event: pygame.event) -> bool:
+    running = True
+
+    if event.type == pygame.QUIT:
+        running = False
+
+    if event.type == pygame.KEYDOWN:
+        # Keyboard button presses
+        if event.key == pygame.K_ESCAPE:
+            running = False
+
+    return running
 
 
 def start_snake_example() -> None:
@@ -83,9 +98,7 @@ def start_snake_example() -> None:
         display.fill((0, 0, 0))
 
         for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                running = False
-                break
+            running = keep_game_running(event)
             if event.type == pygame.VIDEORESIZE:
                 # On window resize, adjust grids accordingly
                 display_height = event.h
@@ -97,13 +110,7 @@ def start_snake_example() -> None:
                                             full_screen.points_from_left(1),
                                             full_screen.points_from_top(1))
 
-            if event.type == pygame.KEYDOWN:
-                # Keyboard button presses
-                if event.key == pygame.K_ESCAPE:
-                    running = False
-                    break
-                
-                snake_direction = determine_snake_direction(event.key, snake_direction)
+            snake_direction = determine_snake_direction(event, snake_direction)
 
         # Draw border
         border = shape_factory.Rect(0, 0, grid.width_gap(0, 10),

--- a/examples/snake_example.py
+++ b/examples/snake_example.py
@@ -21,6 +21,27 @@ class Direction(Enum):
     LEFT = 4
 
 
+def determine_snake_position(snake_direction: Direction, snake_head_top: int, snake_head_left: int) -> tuple:
+    if snake_direction == Direction.UP:
+        snake_head_top -= 1
+        if snake_head_top == -1:
+            snake_head_top = 9
+    elif snake_direction == Direction.RIGHT:
+        snake_head_left += 1
+        if snake_head_left == 10:
+            snake_head_left = 0
+    elif snake_direction == Direction.DOWN:
+        snake_head_top += 1
+        if snake_head_top == 10:
+            snake_head_top = 0
+    elif snake_direction == Direction.LEFT:
+        snake_head_left -= 1
+        if snake_head_left == -1:
+            snake_head_left = 9
+    
+    return snake_head_top, snake_head_left
+
+
 def start_snake_example() -> None:
     running = True
     display = pygame.display.set_mode((300, 300), pygame.RESIZABLE)
@@ -83,22 +104,8 @@ def start_snake_example() -> None:
         pygame.draw.rect(display, (255, 255, 255), border)
 
         # Draw snake position
-        if snake_direction == Direction.UP:
-            snake_head_top -= 1
-            if snake_head_top == -1:
-                snake_head_top = 9
-        elif snake_direction == Direction.RIGHT:
-            snake_head_left += 1
-            if snake_head_left == 10:
-                snake_head_left = 0
-        elif snake_direction == Direction.DOWN:
-            snake_head_top += 1
-            if snake_head_top == 10:
-                snake_head_top = 0
-        elif snake_direction == Direction.LEFT:
-            snake_head_left -= 1
-            if snake_head_left == -1:
-                snake_head_left = 9
+        get_positions = determine_snake_position(snake_direction, snake_head_top, snake_head_left)
+        snake_head_top, snake_head_left = get_positions
 
         # Create the snake head
         head_rect = shape_factory.Rect(snake_head_left, snake_head_top,

--- a/examples/snake_example.py
+++ b/examples/snake_example.py
@@ -21,6 +21,23 @@ class Direction(Enum):
     LEFT = 4
 
 
+def determine_snake_direction(event_key: int, snake_direction: Direction) -> Direction:
+    if event_key == pygame.K_UP and \
+            snake_direction != Direction.DOWN:
+        return Direction.UP
+    elif event_key == pygame.K_RIGHT and \
+            snake_direction != Direction.LEFT:
+        return Direction.RIGHT
+    elif event_key == pygame.K_DOWN and \
+            snake_direction != Direction.UP:
+        return Direction.DOWN
+    elif event_key == pygame.K_LEFT and \
+            snake_direction != Direction.RIGHT:
+        return Direction.LEFT
+    
+    return snake_direction
+
+
 def determine_snake_position(snake_direction: Direction, snake_head_top: int, snake_head_left: int) -> tuple:
     if snake_direction == Direction.UP:
         snake_head_top -= 1
@@ -38,7 +55,7 @@ def determine_snake_position(snake_direction: Direction, snake_head_top: int, sn
         snake_head_left -= 1
         if snake_head_left == -1:
             snake_head_left = 9
-    
+
     return snake_head_top, snake_head_left
 
 
@@ -85,18 +102,8 @@ def start_snake_example() -> None:
                 if event.key == pygame.K_ESCAPE:
                     running = False
                     break
-                if event.key == pygame.K_UP and \
-                        snake_direction != Direction.DOWN:
-                    snake_direction = Direction.UP
-                elif event.key == pygame.K_RIGHT and \
-                        snake_direction != Direction.LEFT:
-                    snake_direction = Direction.RIGHT
-                elif event.key == pygame.K_DOWN and \
-                        snake_direction != Direction.UP:
-                    snake_direction = Direction.DOWN
-                elif event.key == pygame.K_LEFT and \
-                        snake_direction != Direction.RIGHT:
-                    snake_direction = Direction.LEFT
+                
+                snake_direction = determine_snake_direction(event.key, snake_direction)
 
         # Draw border
         border = shape_factory.Rect(0, 0, grid.width_gap(0, 10),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=54",
+    "setuptools>=75.1.0",
     "wheel",
-    "pygame>=2.1.2"
+    "pygame>=2.6"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pygame>=2.1.2
+pygame>=2.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pygame-gridcalculator
-version = 2.0.0
+version = 3.0.0
 author = Dave Harding
 author_email = dave@punkamania.org
 description = For generating a virtual grid to map pixels against and generate shapes from for a pygame display.
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.12
 include_package_data = False
 install_requires =
-    pygame>=2.1.2
+    pygame>=2.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pygame-gridcalculator
-version = 3.0.0
+version = 2.1.0
 author = Dave Harding
 author_email = dave@punkamania.org
 description = For generating a virtual grid to map pixels against and generate shapes from for a pygame display.
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.12
+python_requires = >=3.10
 include_package_data = False
 install_requires =
     pygame>=2.6


### PR DESCRIPTION
This changes the existing support for this library up to Python 3.12, from the current base of Python 3.8.

Whilst checks still occur against Python 3.10 and 3.11, the recommendation will be to use 3.12 going forward.