### PR TITLE
v2.1.0: Amend Publish Action to use Python 3.12

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This amends the existing GitHub action to use Python 3.12 to publish instead of 3.8.